### PR TITLE
turn boxes back off

### DIFF
--- a/react-checkbox-group.jsx
+++ b/react-checkbox-group.jsx
@@ -61,6 +61,8 @@ module.exports = React.createClass({
       // (auto conversion to valid html value from React)
       if (destinationValue.indexOf($checkbox.value) >= 0) {
         $checkbox.checked = true;
+      } else {
+        $checkbox.checked = false;
       }
     }
   },


### PR DESCRIPTION
this came up when using the redux-debuger, basically if an event is forcing a check box to be turned off this won't do it