### PR TITLE
Add support for custom checkbox rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,32 @@ function handleChange(newValues) {
 }
 ```
 
+Optionally, specify a component to be used to render the checkboxes:
+
+```javascript
+// Component that renders a checkbox, e.g. the Checkbox component from `react-bootstrap`
+var CustomCheckbox = (props) => (
+  <label className="custom">
+    <input type="checkbox" {...props} />
+    {props.label}
+  </label>
+);
+
+// ...
+
+<CheckboxGroup name="fruits" value={['kiwi', 'pineapple']} onChange={this.fruitsChanged} componentClass={CustomCheckbox}>
+  {
+    Checkbox => (
+      <div>
+        <Checkbox label="Master Kiwi" value="kiwi"/>
+        <Checkbox label="Super Pineapple" value="pineapple"/>
+        <Checkbox label="Awesome Watermelon" value="watermelon"/>
+      </div>
+    )
+  }
+</CheckboxGroup>
+```
+
 That's it for the API! See below for a complete example.
 
 ## Install

--- a/react-checkbox-group.jsx
+++ b/react-checkbox-group.jsx
@@ -1,14 +1,14 @@
 var React = require('react');
 
-function checkbox(name, checkedValues, onChange) {
+function checkbox(Component, name, checkedValues, onChange) {
   return function Checkbox(props) {
     var checked = checkedValues.indexOf(props.value) >= 0;
     let boxChange = onChange.bind(null, props.value);
 
     return (
-      <input
+      <Component
         {...props}
-        type="checkbox"
+        type={Component === 'input' ? 'checkbox': null}
         name={name}
         checked={checked}
         onChange={boxChange}
@@ -66,7 +66,9 @@ module.exports = React.createClass({
       checkedValues = value;
     }
 
-    var renderedChildren = children(checkbox(name, checkedValues, this.onCheckboxChange));
+    var Component = this.props.componentClass || 'input';
+
+    var renderedChildren = children(checkbox(Component, name, checkedValues, this.onCheckboxChange));
     return renderedChildren && React.Children.only(renderedChildren);
   },
 });

--- a/test/react-checkbox-group_spec.js
+++ b/test/react-checkbox-group_spec.js
@@ -187,4 +187,31 @@ describe('ReactCheckboxGroup', function() {
     expect(newFruits).to.include('pineapple');
     expect(newFruits).to.include('watermelon');
   });
+
+  it('Supports rendering a custom checkbox component', function() {
+    // Component that renders a checkbox, e.g. the Checkbox component from `react-bootstrap`
+    var CustomCheckbox = (props) => (
+      <label className="custom">
+        <input type="checkbox" {...props} />
+        {props.label}
+      </label>
+    );
+
+    var component = renderIntoDocument(
+      <CheckboxGroup name="fruit" componentClass={CustomCheckbox}>
+        {
+          Checkbox => (
+            <div>
+              <Checkbox label="Super Kiwi" value="kiwi"/>
+              <Checkbox label="Awesome Watermelon" value="watermelon"/>
+            </div>
+          )
+        }
+      </CheckboxGroup>
+    );
+    var elements = ReactDOM.findDOMNode(component).querySelectorAll('.custom');
+
+    expect(elements.length).to.equal(2);
+    expect(elements[0].textContent).to.equal('Super Kiwi');
+  });
 });


### PR DESCRIPTION
This adds a `componentClass` prop, used to specify the component to use
for rendering the checkboxes in the CheckboxGroup.

Fixes #14.