### PR TITLE
Pass event as second argument

### DIFF
--- a/react-checkbox-group.js
+++ b/react-checkbox-group.js
@@ -29,10 +29,10 @@ var Checkbox = exports.Checkbox = _react2.default.createClass({
   },
 
   render: function render() {
-    var _context$checkboxGrou = this.context.checkboxGroup,
-        name = _context$checkboxGrou.name,
-        checkedValues = _context$checkboxGrou.checkedValues,
-        onChange = _context$checkboxGrou.onChange;
+    var _context$checkboxGrou = this.context.checkboxGroup;
+    var name = _context$checkboxGrou.name;
+    var checkedValues = _context$checkboxGrou.checkedValues;
+    var onChange = _context$checkboxGrou.onChange;
 
     var optional = {};
     if (checkedValues) {
@@ -50,7 +50,7 @@ var Checkbox = exports.Checkbox = _react2.default.createClass({
   }
 });
 
-var CheckboxGroup = _react2.default.createClass({
+var CheckboxGroup = exports.CheckboxGroup = _react2.default.createClass({
   displayName: 'CheckboxGroup',
 
   propTypes: {
@@ -97,13 +97,14 @@ var CheckboxGroup = _react2.default.createClass({
   },
 
   render: function render() {
-    var _props = this.props,
-        Component = _props.Component,
-        name = _props.name,
-        value = _props.value,
-        onChange = _props.onChange,
-        children = _props.children,
-        rest = _objectWithoutProperties(_props, ['Component', 'name', 'value', 'onChange', 'children']);
+    var _props = this.props;
+    var Component = _props.Component;
+    var name = _props.name;
+    var value = _props.value;
+    var onChange = _props.onChange;
+    var children = _props.children;
+
+    var rest = _objectWithoutProperties(_props, ['Component', 'name', 'value', 'onChange', 'children']);
 
     return _react2.default.createElement(
       Component,
@@ -141,4 +142,3 @@ var CheckboxGroup = _react2.default.createClass({
     }
   }
 });
-exports.CheckboxGroup = CheckboxGroup;

--- a/react-checkbox-group.js
+++ b/react-checkbox-group.js
@@ -138,7 +138,7 @@ var CheckboxGroup = exports.CheckboxGroup = _react2.default.createClass({
     }
 
     if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newValue, event);
+      this.props.onChange(newValue);
     }
   }
 });

--- a/react-checkbox-group.js
+++ b/react-checkbox-group.js
@@ -29,10 +29,10 @@ var Checkbox = exports.Checkbox = _react2.default.createClass({
   },
 
   render: function render() {
-    var _context$checkboxGrou = this.context.checkboxGroup;
-    var name = _context$checkboxGrou.name;
-    var checkedValues = _context$checkboxGrou.checkedValues;
-    var onChange = _context$checkboxGrou.onChange;
+    var _context$checkboxGrou = this.context.checkboxGroup,
+        name = _context$checkboxGrou.name,
+        checkedValues = _context$checkboxGrou.checkedValues,
+        onChange = _context$checkboxGrou.onChange;
 
     var optional = {};
     if (checkedValues) {
@@ -50,7 +50,7 @@ var Checkbox = exports.Checkbox = _react2.default.createClass({
   }
 });
 
-var CheckboxGroup = exports.CheckboxGroup = _react2.default.createClass({
+var CheckboxGroup = _react2.default.createClass({
   displayName: 'CheckboxGroup',
 
   propTypes: {
@@ -97,14 +97,13 @@ var CheckboxGroup = exports.CheckboxGroup = _react2.default.createClass({
   },
 
   render: function render() {
-    var _props = this.props;
-    var Component = _props.Component;
-    var name = _props.name;
-    var value = _props.value;
-    var onChange = _props.onChange;
-    var children = _props.children;
-
-    var rest = _objectWithoutProperties(_props, ['Component', 'name', 'value', 'onChange', 'children']);
+    var _props = this.props,
+        Component = _props.Component,
+        name = _props.name,
+        value = _props.value,
+        onChange = _props.onChange,
+        children = _props.children,
+        rest = _objectWithoutProperties(_props, ['Component', 'name', 'value', 'onChange', 'children']);
 
     return _react2.default.createElement(
       Component,
@@ -138,7 +137,8 @@ var CheckboxGroup = exports.CheckboxGroup = _react2.default.createClass({
     }
 
     if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newValue);
+      this.props.onChange(newValue, event);
     }
   }
 });
+exports.CheckboxGroup = CheckboxGroup;

--- a/react-checkbox-group.js
+++ b/react-checkbox-group.js
@@ -138,7 +138,7 @@ var CheckboxGroup = exports.CheckboxGroup = _react2.default.createClass({
     }
 
     if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newValue);
+      this.props.onChange(newValue, event);
     }
   }
 });

--- a/react-checkbox-group.jsx
+++ b/react-checkbox-group.jsx
@@ -114,7 +114,7 @@ export const CheckboxGroup = React.createClass({
     }
 
     if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newValue);
+      this.props.onChange(newValue, event);
     }
   }
 });


### PR DESCRIPTION
Hi,

first of all: thanks for your tiny but great component. Very useful!

I needed a way to send formdata via AJAX as soon as a checkbox gets checked. So I added the event as last argument to the `onChange` handler so I can do something like:
```
<CheckboxGroup onChange={ (values, event) => { serialize(event.target.form); [...] }}>
   [...]
</CheckboxGroup>
```

I hope that's okay for you. I would love it even more to see it as first argument of the `onChange` handler as it is when a "real" onChange event occurs but since it would be a breaking change, passing it as second parameter would be okay for me 😉 

// edit
by the way: react-radio-group seems to work exactly like that. Second argument is the proxied event :smiley: