### PR TITLE
Es6 class rewrite

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,7 @@
 {
   "presets": [
     "react",
-    "es2015",
-    "stage-2"
+    "es2015"
   ],
-  "plugins": "transform-object-rest-spread"
+  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,7 @@
 {
   "presets": [
     "react",
-    "es2015",
-    "stage-2"
+    "es2015"
   ],
   "plugins": "transform-object-rest-spread"
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,8 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": [
+    "react",
+    "es2015",
+    "stage-2"
+  ],
   "plugins": "transform-object-rest-spread"
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     "react",
-    "es2015"
+    "es2015",
+    "stage-2"
   ],
   "plugins": "transform-object-rest-spread"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js  --recursive",
     "test:watch": "npm run test -- --watch",
+    "lint": "eslint \"react-checkbox-group.jsx\"",
     "prepublish": "babel ./react-checkbox-group.jsx --out-file ./react-checkbox-group.js"
   },
   "repository": {
@@ -30,13 +31,33 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.1.18",
+    "babel-preset-stage-2": "^6.18.0",
+    "babel-eslint": "^6.0.2",
+    "eslint-config-xo-react": "^0.7.0",
+    "eslint-config-xo-space": "^0.12.0",
+    "eslint-plugin-babel": "^3.1.0",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-react": "^5.0.1",
+    "eslint-plugin-standard": "^2.1.1",
+    "eslint": "^3.18.0",
     "chai": "^3.5.0",
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1"
+  },
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "browser": true,
+      "mocha": true
+    },
+    "extends": [
+      "xo-react/space",
+      "xo-space/esnext"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,14 +30,15 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.1.18",
-    "babel-preset-stage-2": "^6.18.0",
     "chai": "^3.5.0",
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "react-dom": "^15.0.1",
+    "prop-types": "^15.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js  --recursive",
     "test:watch": "npm run test -- --watch",
-    "lint": "eslint \"react-checkbox-group.jsx\"",
     "prepublish": "babel ./react-checkbox-group.jsx --out-file ./react-checkbox-group.js"
   },
   "repository": {
@@ -34,30 +33,11 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-2": "^6.18.0",
-    "babel-eslint": "^6.0.2",
-    "eslint-config-xo-react": "^0.7.0",
-    "eslint-config-xo-space": "^0.12.0",
-    "eslint-plugin-babel": "^3.1.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^5.0.1",
-    "eslint-plugin-standard": "^2.1.1",
-    "eslint": "^3.18.0",
     "chai": "^3.5.0",
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "browser": true,
-      "mocha": true
-    },
-    "extends": [
-      "xo-react/space",
-      "xo-space/esnext"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-checkbox-group",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Sensible checkbox groups manipulation for DOM.",
   "main": "react-checkbox-group.js",
   "scripts": {

--- a/react-checkbox-group.js
+++ b/react-checkbox-group.js
@@ -7,138 +7,177 @@ exports.CheckboxGroup = exports.Checkbox = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var Checkbox = exports.Checkbox = _react2.default.createClass({
-  displayName: 'Checkbox',
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  contextTypes: {
-    checkboxGroup: _react2.default.PropTypes.object.isRequired
-  },
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  componentWillMount: function componentWillMount() {
-    if (!(this.context && this.context.checkboxGroup)) {
-      throw new Error('The `Checkbox` component must be used as a child of `CheckboxGroup`.');
-    }
-  },
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-  render: function render() {
-    var _context$checkboxGrou = this.context.checkboxGroup;
-    var name = _context$checkboxGrou.name;
-    var checkedValues = _context$checkboxGrou.checkedValues;
-    var onChange = _context$checkboxGrou.onChange;
+// Original version https://github.com/ziad-saab/react-checkbox-group
 
-    var optional = {};
-    if (checkedValues) {
-      optional.checked = checkedValues.indexOf(this.props.value) >= 0;
-    }
-    if (typeof onChange === 'function') {
-      optional.onChange = onChange.bind(null, this.props.value);
-    }
+var Checkbox = exports.Checkbox = function (_Component) {
+  _inherits(Checkbox, _Component);
 
-    return _react2.default.createElement('input', _extends({}, this.props, {
-      type: 'checkbox',
-      name: name,
-      disabled: this.props.disabled
-    }, optional));
+  function Checkbox() {
+    _classCallCheck(this, Checkbox);
+
+    return _possibleConstructorReturn(this, (Checkbox.__proto__ || Object.getPrototypeOf(Checkbox)).apply(this, arguments));
   }
-});
 
-var CheckboxGroup = exports.CheckboxGroup = _react2.default.createClass({
-  displayName: 'CheckboxGroup',
+  _createClass(Checkbox, [{
+    key: 'componentWillMount',
+    value: function componentWillMount() {
+      if (!(this.context && this.context.checkboxGroup)) {
+        throw new Error('The `Checkbox` component must be used as a child of `CheckboxGroup`.');
+      }
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _context$checkboxGrou = this.context.checkboxGroup,
+          name = _context$checkboxGrou.name,
+          checkedValues = _context$checkboxGrou.checkedValues,
+          onChange = _context$checkboxGrou.onChange;
 
-  propTypes: {
-    name: _react.PropTypes.string,
-    defaultValue: _react.PropTypes.array,
-    value: _react.PropTypes.array,
-    onChange: _react.PropTypes.func,
-    children: _react.PropTypes.node.isRequired,
-    Component: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.func, _react.PropTypes.object])
-  },
+      var optional = {};
+      if (checkedValues) {
+        optional.checked = checkedValues.indexOf(this.props.value) >= 0;
+      }
+      if (typeof onChange === 'function') {
+        optional.onChange = onChange.bind(null, this.props.value);
+      }
 
-  getDefaultProps: function getDefaultProps() {
-    return {
-      Component: "div"
+      return _react2.default.createElement('input', _extends({}, this.props, {
+        type: 'checkbox',
+        name: name,
+        disabled: this.props.disabled
+      }, optional));
+    }
+  }]);
+
+  return Checkbox;
+}(_react.Component);
+
+Checkbox.contextTypes = {
+  checkboxGroup: _propTypes2.default.object.isRequired
+};
+
+var CheckboxGroup = exports.CheckboxGroup = function (_Component2) {
+  _inherits(CheckboxGroup, _Component2);
+
+  function CheckboxGroup(props) {
+    _classCallCheck(this, CheckboxGroup);
+
+    var _this2 = _possibleConstructorReturn(this, (CheckboxGroup.__proto__ || Object.getPrototypeOf(CheckboxGroup)).call(this, props));
+
+    _this2._isControlledComponent = _this2._isControlledComponent.bind(_this2);
+    _this2._onCheckboxChange = _this2._onCheckboxChange.bind(_this2);
+    _this2.getChildContext = _this2.getChildContext.bind(_this2);
+    _this2.getValue = _this2.getValue.bind(_this2);
+    _this2.state = {
+      value: _this2.props.value || _this2.props.defaultValue || []
     };
-  },
+    return _this2;
+  }
 
-  childContextTypes: {
-    checkboxGroup: _react2.default.PropTypes.object
-  },
-
-  getChildContext: function getChildContext() {
-    return {
-      checkboxGroup: {
+  _createClass(CheckboxGroup, [{
+    key: 'getChildContext',
+    value: function getChildContext() {
+      var checkboxGroup = {
         name: this.props.name,
         checkedValues: this.state.value,
         onChange: this._onCheckboxChange
+      };
+      return { checkboxGroup: checkboxGroup };
+    }
+  }, {
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(newProps) {
+      if (newProps.value) {
+        this.setState({
+          value: newProps.value
+        });
       }
-    };
-  },
-
-  getInitialState: function getInitialState() {
-    return {
-      value: this.props.value || this.props.defaultValue || []
-    };
-  },
-
-  componentWillReceiveProps: function componentWillReceiveProps(newProps) {
-    if (newProps.value) {
-      this.setState({
-        value: newProps.value
-      });
     }
-  },
+  }, {
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          Component = _props.Component,
+          name = _props.name,
+          value = _props.value,
+          onChange = _props.onChange,
+          children = _props.children,
+          rest = _objectWithoutProperties(_props, ['Component', 'name', 'value', 'onChange', 'children']);
 
-  render: function render() {
-    var _props = this.props;
-    var Component = _props.Component;
-    var name = _props.name;
-    var value = _props.value;
-    var onChange = _props.onChange;
-    var children = _props.children;
-
-    var rest = _objectWithoutProperties(_props, ['Component', 'name', 'value', 'onChange', 'children']);
-
-    return _react2.default.createElement(
-      Component,
-      rest,
-      children
-    );
-  },
-
-  getValue: function getValue() {
-    return this.state.value;
-  },
-
-  _isControlledComponent: function _isControlledComponent() {
-    return !!this.props.value;
-  },
-
-  _onCheckboxChange: function _onCheckboxChange(checkboxValue, event) {
-    var newValue;
-    if (event.target.checked) {
-      newValue = this.state.value.concat(checkboxValue);
-    } else {
-      newValue = this.state.value.filter(function (v) {
-        return v !== checkboxValue;
-      });
+      return _react2.default.createElement(
+        Component,
+        rest,
+        children
+      );
     }
-
-    if (!this._isControlledComponent()) {
-      this.setState({ value: newValue });
-    } else {
-      this.setState({ value: this.props.value });
+  }, {
+    key: 'getValue',
+    value: function getValue() {
+      return this.state.value;
     }
-
-    if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newValue, event);
+  }, {
+    key: '_isControlledComponent',
+    value: function _isControlledComponent() {
+      return Boolean(this.props.value);
     }
-  }
-});
+  }, {
+    key: '_onCheckboxChange',
+    value: function _onCheckboxChange(checkboxValue, event) {
+      var newValue = void 0;
+      if (event.target.checked) {
+        newValue = this.state.value.concat(checkboxValue);
+      } else {
+        newValue = this.state.value.filter(function (v) {
+          return v !== checkboxValue;
+        });
+      }
+
+      if (this._isControlledComponent()) {
+        this.setState({ value: this.props.value });
+      } else {
+        this.setState({ value: newValue });
+      }
+
+      if (typeof this.props.onChange === 'function') {
+        this.props.onChange(newValue, event);
+      }
+    }
+  }]);
+
+  return CheckboxGroup;
+}(_react.Component);
+
+CheckboxGroup.childContextTypes = {
+  checkboxGroup: _propTypes2.default.object.isRequired
+};
+CheckboxGroup.propTypes = {
+  name: _propTypes2.default.string,
+  defaultValue: _propTypes2.default.array,
+  value: _propTypes2.default.array,
+  onChange: _propTypes2.default.func,
+  children: _propTypes2.default.node.isRequired,
+  Component: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func, _propTypes2.default.object])
+};
+CheckboxGroup.defaultProps = {
+  Component: "div"
+};

--- a/react-checkbox-group.js
+++ b/react-checkbox-group.js
@@ -27,8 +27,6 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-// Original version https://github.com/ziad-saab/react-checkbox-group
-
 var Checkbox = exports.Checkbox = function (_Component) {
   _inherits(Checkbox, _Component);
 

--- a/react-checkbox-group.jsx
+++ b/react-checkbox-group.jsx
@@ -1,25 +1,27 @@
-import React, {PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+// Original version https://github.com/ziad-saab/react-checkbox-group
 
-export const Checkbox = React.createClass({
-  displayName: 'Checkbox',
+export class Checkbox extends Component {
+  displayName: 'Checkbox';
 
-  contextTypes: {
-    checkboxGroup: React.PropTypes.object.isRequired
-  },
+  static contextTypes = {
+    checkboxGroup: PropTypes.object.isRequired
+  }
 
-  componentWillMount: function() {
+  componentWillMount() {
     if (!(this.context && this.context.checkboxGroup)) {
       throw new Error('The `Checkbox` component must be used as a child of `CheckboxGroup`.');
     }
-  },
+  }
 
-  render: function() {
+  render() {
     const {name, checkedValues, onChange} = this.context.checkboxGroup;
     const optional = {};
-    if(checkedValues) {
+    if (checkedValues) {
       optional.checked = (checkedValues.indexOf(this.props.value) >= 0);
     }
-    if(typeof onChange === 'function') {
+    if (typeof onChange === 'function') {
       optional.onChange = onChange.bind(null, this.props.value);
     }
 
@@ -29,15 +31,21 @@ export const Checkbox = React.createClass({
         type="checkbox"
         name={name}
         disabled={this.props.disabled}
-        {...optional} />
+        {...optional}
+        />
     );
   }
-});
+}
 
-export const CheckboxGroup = React.createClass({
-  displayName: 'CheckboxGroup',
 
-  propTypes: {
+export class CheckboxGroup extends Component {
+  displayName: 'CheckboxGroup';
+
+  static childContextTypes = {
+    checkboxGroup: PropTypes.object.isRequired
+  }
+
+  static propTypes = {
     name: PropTypes.string,
     defaultValue: PropTypes.array,
     value: PropTypes.array,
@@ -46,75 +54,71 @@ export const CheckboxGroup = React.createClass({
     Component: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func,
-      PropTypes.object,
+      PropTypes.object
     ])
-  },
+  }
 
-  getDefaultProps: function() {
-    return {
-      Component: "div"
-    };
-  },
+  static defaultProps = {
+    Component: "div"
+  }
 
-  childContextTypes: {
-    checkboxGroup: React.PropTypes.object
-  },
-
-  getChildContext: function() {
-    return {
-      checkboxGroup: {
-        name: this.props.name,
-        checkedValues: this.state.value,
-        onChange: this._onCheckboxChange
-      }
-    }
-  },
-
-  getInitialState: function() {
-    return {
+  constructor(props) {
+    super(props);
+    this._isControlledComponent = this._isControlledComponent.bind(this);
+    this._onCheckboxChange = this._onCheckboxChange.bind(this);
+    this.getChildContext = this.getChildContext.bind(this);
+    this.getValue = this.getValue.bind(this);
+    this.state = {
       value: this.props.value || this.props.defaultValue || []
-    }
-  },
+    };
+  }
 
-  componentWillReceiveProps: function(newProps) {
+  getChildContext() {
+    const checkboxGroup = {
+      name: this.props.name,
+      checkedValues: this.state.value,
+      onChange: this._onCheckboxChange
+    };
+    return {checkboxGroup};
+  }
+
+  componentWillReceiveProps(newProps) {
     if (newProps.value) {
       this.setState({
         value: newProps.value
       });
     }
-  },
+  }
 
-  render: function() {
+  render() {
     const {Component, name, value, onChange, children, ...rest} = this.props;
     return <Component {...rest}>{children}</Component>;
-  },
+  }
 
-  getValue: function() {
+  getValue() {
     return this.state.value;
-  },
+  }
 
-  _isControlledComponent: function() {
-    return !!this.props.value;
-  },
+  _isControlledComponent() {
+    return Boolean(this.props.value);
+  }
 
-  _onCheckboxChange: function(checkboxValue, event) {
-    var newValue;
+  _onCheckboxChange(checkboxValue, event) {
+    let newValue;
     if (event.target.checked) {
       newValue = this.state.value.concat(checkboxValue);
-    }
-    else {
+    } else {
       newValue = this.state.value.filter(v => v !== checkboxValue);
     }
 
-    if (!this._isControlledComponent()) {
-      this.setState({value: newValue});
-    }
-    else {
+    if (this._isControlledComponent()) {
       this.setState({value: this.props.value});
+    } else {
+      this.setState({value: newValue});
     }
 
     if (typeof this.props.onChange === 'function') {
       this.props.onChange(newValue, event);
     }
   }
-});
+}

--- a/react-checkbox-group.jsx
+++ b/react-checkbox-group.jsx
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-// Original version https://github.com/ziad-saab/react-checkbox-group
 
 export class Checkbox extends Component {
   displayName: 'Checkbox';
@@ -36,7 +35,6 @@ export class Checkbox extends Component {
     );
   }
 }
-
 
 export class CheckboxGroup extends Component {
   displayName: 'CheckboxGroup';


### PR DESCRIPTION
Since React.createClass is deprecated and may be removed soon, it may be good to use es6 classes.