### PR TITLE
Checkbox group name added as a prop to onChange

### DIFF
--- a/react-checkbox-group.jsx
+++ b/react-checkbox-group.jsx
@@ -116,7 +116,7 @@ export class CheckboxGroup extends Component {
     }
 
     if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newValue, event);
+      this.props.onChange(newValue, this.props.name, event);
     }
   }
 }

--- a/react-checkbox-group.jsx
+++ b/react-checkbox-group.jsx
@@ -116,7 +116,7 @@ export class CheckboxGroup extends Component {
     }
 
     if (typeof this.props.onChange === 'function') {
-      this.props.onChange(newValue, this.props.name, event);
+      this.props.onChange(newValue, event, this.props.name);
     }
   }
 }


### PR DESCRIPTION
Make checkbox group name available in onChange functions so that generalized setState functions are made possible.

So instead of:
`  fruitsChanged = (newFruits) => {
    this.setState({
      fruits: newFruits
    });
  }`

where the handle change function cannot be reused from one checkbox group component to another, we can do:
`  anyValuesChanged = (newValues, name) => {
    this.setState({
      [name]: newValues
    });
  }`

But where the user doesn't need / want checkbox group name access, it doesn't affect the flow of anything else (the fruitsChanged original example would still work the same).